### PR TITLE
Add installer and auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,7 @@ name: "Release"
 on:
   push:
     tags:
-      - "v*"
-
-env:
-  PROJECT_PATH: PboExplorer/PboExplorer.csproj
+       - "*.*.*"
 
 jobs:
   release:
@@ -21,21 +18,34 @@ jobs:
           dotnet-version: 6.0.x
 
       - name: Restore
-        run: dotnet restore ${{ env.PROJECT_PATH }}
+        run: dotnet restore --packages packages
 
       - name: Build
-        run: >
-          dotnet build ${{ env.PROJECT_PATH }} -c Release --no-restore
-          --self-contained=false -r win-x64 -p:PublishSingleFile=true
+        run: dotnet build -c Release -o ".\publish" --no-restore
+      
+      - name: Fetch previous release
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          packages\clowd.squirrel\2.9.42\tools\Squirrel.exe `
+          Squirrel github-down --repoUrl "https://github.com/FlipperPlz/PboExplorer"
 
       - name: Publish
-        run: >
-          dotnet publish ${{ env.PROJECT_PATH }} -c Release -o Releases --no-build
-          --self-contained=false -r win-x64 -p:PublishSingleFile=true
+        shell: pwsh
+        run: |
+          packages\clowd.squirrel\2.9.42\tools\Squirrel.exe  pack `
+          --framework net6 `
+          --packId "PboExplorer" `
+          --packVersion "${{github.ref_name}}" `
+          --packAuthors "${{github.repository_owner}}" `
+          --packDir ".\publish"
 
       - name: Create release
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           draft: true
-          files: Releases/*.exe
+          files: |
+            Releases/RELEASES
+            Releases/*.exe
+            Releases/*.nupkg

--- a/PboExplorer/App.xaml.cs
+++ b/PboExplorer/App.xaml.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using Squirrel;
 
 namespace PboExplorer
 {
@@ -13,5 +14,17 @@ namespace PboExplorer
     /// </summary>
     public partial class App : Application
     {
+        protected override async void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            SquirrelAwareApp.HandleEvents(
+                onInitialInstall: InstallerConfiguration.OnAppInstall,
+                onAppUninstall: InstallerConfiguration.OnAppUninstall,
+                onEveryRun: InstallerConfiguration.OnAppRun
+            );
+
+            await InstallerConfiguration.UpdateApp();
+        }
     }
 }

--- a/PboExplorer/InstallerConfiguration.cs
+++ b/PboExplorer/InstallerConfiguration.cs
@@ -1,0 +1,31 @@
+﻿using Squirrel;
+using System.Threading.Tasks;
+
+namespace PboExplorer;
+
+internal static  class InstallerConfiguration
+{
+    public static void OnAppInstall(SemanticVersion version, IAppTools tools)
+    {
+        tools.CreateShortcutForThisExe(ShortcutLocation.StartMenu | ShortcutLocation.Desktop);
+    }
+
+    public static void OnAppUninstall(SemanticVersion version, IAppTools tools)
+    {
+        tools.RemoveShortcutForThisExe(ShortcutLocation.StartMenu | ShortcutLocation.Desktop);
+    }
+
+    public static void OnAppRun(SemanticVersion version, IAppTools tools, bool firstRun)
+    {
+        tools.SetProcessAppUserModelId();
+    }
+
+    public static async Task UpdateApp()
+    {
+        using var mgr = new GithubUpdateManager("https://github.com/FlipperPlz/PboExplorer");
+        if (mgr.IsInstalledApp)
+        {
+            await mgr.UpdateApp();
+        };
+    }
+}

--- a/PboExplorer/PboExplorer.csproj
+++ b/PboExplorer/PboExplorer.csproj
@@ -6,11 +6,13 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
 	<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+	<ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BisUtils.Core" Version="1.0.31" />
     <PackageReference Include="BisUtils.PBO" Version="1.0.11" />
+    <PackageReference Include="Clowd.Squirrel" Version="2.9.42" />
   </ItemGroup>
 
 </Project>

--- a/PboExplorer/app.manifest
+++ b/PboExplorer/app.manifest
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <SquirrelAwareVersion xmlns="urn:schema-squirrel-com:asm.v1">1</SquirrelAwareVersion>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
I added Clowd.Squirrel ([more about it in repo](https://github.com/clowd/Clowd.Squirrel)) wizard-free installer with auto-update feature. The release process is now as simple as pushing SemVer tag (e.g. `0.0.1` ) and then approving release draft. The user's installation will be automatically updated the next time the application is launched after release.

I've changed tag format from **v**X.X.* to just X.X.* (no prefix) to simplify workflow, because `Squirrel.exe` doesn't allow prefixes in version parameter. I hope it's not a big deal because there are no tags in the repo yet and you can choose an arbitrary format.

*\* release under `0.0.0` version actually isn't supported by nuget and so Squirrel*