### PR TITLE
Move About info to separate view

### DIFF
--- a/PboExplorer/Views/AboutView.xaml
+++ b/PboExplorer/Views/AboutView.xaml
@@ -1,0 +1,74 @@
+﻿<UserControl x:Class="PboExplorer.Views.AboutView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:PboExplorer.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="800" d:DesignWidth="600">
+    <Grid Background="LightGray">
+        <FlowDocumentScrollViewer VerticalScrollBarVisibility="Auto">
+            <FlowDocument>
+                <Paragraph FontWeight="Bold">
+                    Remarks: If your are not the author of the files, you have to ensure that files
+                        licence allows you to manipulate them (extract, re-use or edit them). If your
+                        are not sure about this, you must get approval from the author of the files.
+                </Paragraph>
+
+                <Paragraph>
+                    PBO Explorer version 0.0.0
+                </Paragraph>
+                <Paragraph>
+                    <Hyperlink NavigateUri="https://github.com/FlipperPlz/PboExplorer" 
+                               RequestNavigate="OnRequestNavigate">
+                        https://github.com/FlipperPlz/PboExplorer
+                    </Hyperlink>
+                </Paragraph>
+
+                <Paragraph>
+                    Copyright (c) 2021-2022 FlipperPlz
+                    <LineBreak/>
+                    Powered By
+                    <Hyperlink NavigateUri="https://github.com/FlipperPlz/BisUtils" 
+                               RequestNavigate="OnRequestNavigate">
+                        BisUtils
+                    </Hyperlink>
+                </Paragraph>
+                <Section FontFamily="Mono">
+                    <Paragraph>
+                        GPL License
+                    </Paragraph>
+
+                    <Paragraph>
+                        Copyright (c) 2022 FlipperPlz - Rewrite
+                        <LineBreak />
+                        Copyright (c) 2021-2022 Julien Etelain (aka GrueArbre)
+                    </Paragraph>
+
+                    <Paragraph>
+                        Permission is hereby granted, free of charge, to any person obtaining a copy
+                            of this software and associated documentation files (the "Software"), to deal
+                            in the Software without restriction, including without limitation the rights
+                            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                            copies of the Software, and to permit persons to whom the Software is
+                            furnished to do so, subject to the following conditions:
+                    </Paragraph>
+                    <Paragraph>
+                        The above copyright notice and this permission notice shall be included in all
+                            copies or substantial portions of the Software.
+                    </Paragraph>
+                    <Paragraph>
+                        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                            FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+                            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                            SOFTWARE.
+                    </Paragraph>
+                </Section>
+
+            </FlowDocument>
+        </FlowDocumentScrollViewer>
+    </Grid>
+</UserControl>

--- a/PboExplorer/Views/AboutView.xaml.cs
+++ b/PboExplorer/Views/AboutView.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace PboExplorer.Views
+{
+    /// <summary>
+    /// Interaction logic for AboutView.xaml
+    /// </summary>
+    public partial class AboutView : UserControl
+    {
+        public AboutView()
+        {
+            InitializeComponent();
+        }
+
+        private void OnRequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            var link = (Hyperlink)sender;
+            var navigateUri = link.NavigateUri.ToString();
+            Process.Start(new ProcessStartInfo(navigateUri) { UseShellExecute = true }) ;
+            e.Handled = true;
+        }
+    }
+}

--- a/PboExplorer/Windows/PboExplorerWindow.xaml
+++ b/PboExplorer/Windows/PboExplorerWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:treeItems="clr-namespace:PboExplorer.TreeItems"
         xmlns:utils="clr-namespace:PboExplorer.Utils"
         xmlns:elements="clr-namespace:PboExplorer.Utils.Elements"
+        xmlns:views="clr-namespace:PboExplorer.Views"
         mc:Ignorable="d"
         Title="PboExplorerWindow" Height="450" Width="800">
     
@@ -242,49 +243,9 @@
                         </Grid>
                         
                     </TabItem>
-                    <TabItem
-                        Header="About Program">
-                        <Grid Background="LightGray" Margin="0 5 0 0">
-                            <ScrollViewer Name="AboutBox" Margin="10">
-                                <TextBlock>
-                            <Bold>
-                            Remarks: If your are not the author of the files, you have to ensure that files<LineBreak /> 
-                            licence allows you to manipulate them (extract, re-use or edit them). If your<LineBreak /> 
-                            are not sure about this, you must get approval from the author of the files.</Bold><LineBreak />
-                            <LineBreak />
-                            PBO Explorer version 0.0.0<LineBreak />
-                            <Hyperlink NavigateUri="https://github.com/FlipperPlz/PboExplorer" RequestNavigate="Hyperlink_RequestNavigate">https://github.com/jetelain/PboExplorer</Hyperlink>
-                            <LineBreak />
-                            <LineBreak />
-                            Copyright (c) 2021-2022 FlipperPlz<LineBreak />
-                            Powered By BisUtils
-                            <LineBreak />
-                            <LineBreak />
-                            GPL License<LineBreak />
-                            <LineBreak />
-                            Copyright (c) 2022 FlipperPlz - Rewrite<LineBreak />
-                            Copyright (c) 2021-2022 Julien Etelain (aka GrueArbre) <LineBreak />
-                            <LineBreak />
-                            Permission is hereby granted, free of charge, to any person obtaining a copy<LineBreak />
-                            of this software and associated documentation files (the "Software"), to deal<LineBreak />
-                            in the Software without restriction, including without limitation the rights<LineBreak />
-                            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell<LineBreak />
-                            copies of the Software, and to permit persons to whom the Software is<LineBreak />
-                            furnished to do so, subject to the following conditions:<LineBreak />
-                            <LineBreak />
-                            The above copyright notice and this permission notice shall be included in all<LineBreak />
-                            copies or substantial portions of the Software.<LineBreak />
-                            <LineBreak />
-                            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR<LineBreak />
-                            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,<LineBreak />
-                            FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE<LineBreak />
-                            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER<LineBreak />
-                            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,<LineBreak />
-                            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE<LineBreak />
-                            SOFTWARE.
-                                </TextBlock>
-                            </ScrollViewer>
-                        </Grid>
+                    <TabItem  Header="About Program"
+                              ScrollViewer.VerticalScrollBarVisibility="Visible">
+                        <views:AboutView/>
                     </TabItem>
                 </TabControl>
 

--- a/PboExplorer/Windows/PboExplorerWindow.xaml.cs
+++ b/PboExplorer/Windows/PboExplorerWindow.xaml.cs
@@ -139,10 +139,6 @@ namespace PboExplorer.Windows
         private void ShowSearchResult(object sender, SelectionChangedEventArgs e) {
         }
 
-        private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e) {
-            
-        }
-
         private void SubmitSearch(object sender, RoutedEventArgs e) {
             
         }


### PR DESCRIPTION
Moved information about program to `Views\AboutView` (not sure about naming so I followed common practices) to reduce clutter in `PboExlplorerWindow` (remove about 40 lines).  I also changed the `TextBlock` component to a `FlowDocument` to make it responsive and added hyperlink navigation.

![image](https://user-images.githubusercontent.com/48875452/207686630-cc8e93fe-d106-46b1-a6e7-037f08e039ff.png)
