### PR TITLE
Add Most Recently Used files list to SplashWindow

### DIFF
--- a/PboExplorer/PboExplorer.csproj
+++ b/PboExplorer/PboExplorer.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="BisUtils.Core" Version="1.0.34" />
     <PackageReference Include="BisUtils.PBO" Version="1.0.22" />
     <PackageReference Include="Clowd.Squirrel" Version="2.9.42" />
+    <PackageReference Include="Dirkster.MRULib" Version="1.3.0" />
     <PackageReference Include="System.Runtime.Caching" Version="7.0.0" />
   </ItemGroup>
 

--- a/PboExplorer/ViewModels/SplashViewModel.cs
+++ b/PboExplorer/ViewModels/SplashViewModel.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Windows;
+using System.Windows.Input;
+using Microsoft.Win32;
+
+using MRULib;
+using MRULib.MRU.Enums;
+using MRULib.MRU.Interfaces;
+using MRULib.MRU.Models.Persist;
+using MRULib.MRU.ViewModels.Base;
+
+using BisUtils.PBO;
+using PboExplorer.Windows;
+
+
+namespace PboExplorer.ViewModels;
+
+internal class SplashViewModel : INotifyPropertyChanged
+{
+    private const string _mruFile = "mru.xml";
+
+    public IMRUListViewModel MRUFileList { get; }
+
+    public ICommand CreatePBOCommand { get; }
+    public ICommand OpenPBOCommand { get; }
+
+    public ICommand NavigateUriCommand { get; }
+    public ICommand ClearAllItemsCommand { get; }
+    public ICommand RemoveItemCommand { get; }
+    public ICommand MovePinnedMruItemUpCommand { get; }
+    public ICommand MovePinnedMruItemDownCommand { get; }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public event EventHandler? CloseRequested;
+
+    public SplashViewModel()
+    {
+        try
+        {
+            MRUFileList = MRUEntrySerializer.Load(_mruFile);
+        }
+        catch (FileNotFoundException)
+        {
+            MRUFileList = MRU_Service.Create_List();
+        }
+
+        // TODO: In case of adoption MVVM framework replace MRULib's RelayCommand
+        CreatePBOCommand = new RelayCommand<object>(_ => CreateNewPBO());
+        OpenPBOCommand = new RelayCommand<object>(_ => OpenPBOFileWithDialog());
+        NavigateUriCommand = new RelayCommand<string>(OpenPBOFfile);
+        ClearAllItemsCommand = new RelayCommand<object>(_ => ClearMRU());
+        RemoveItemCommand = new RelayCommand<object>((p) => RemoveMRUItem(p as IMRUEntryViewModel));
+        MovePinnedMruItemUpCommand = new RelayCommand<object>(MovePinnedMruItemUp, CanMovePinnedMruItemUp);
+        MovePinnedMruItemDownCommand = new RelayCommand<object>(MovePinnedMruItemDown, CanMovePinnedMruItemDown);
+    }
+
+    private void UpdateMRUItem(string path)
+    {
+        MRUFileList.UpdateEntry(path);
+        SaveMRU();
+    }
+
+    private void ClearMRU()
+    {
+        MRUFileList.Clear();
+        SaveMRU();
+    }
+
+    private void RemoveMRUItem(IMRUEntryViewModel? entry)
+    {
+        MRUFileList.RemoveEntry(entry);
+        SaveMRU();
+    }
+
+    // TODO: Make method async in case of adoption AsyncRelayCommand
+    private void SaveMRU()
+    {
+        string persistPath = Path.Combine(_mruFile);
+        MRUEntrySerializer.Save(persistPath, MRUFileList);
+    }
+
+    private bool CanMovePinnedMruItemUp(object p)
+    {
+        if (p is IMRUEntryViewModel == false)
+            return false;
+
+        if ((p as IMRUEntryViewModel)?.IsPinned == 0)  //Make sure it is pinned
+            return false;
+
+        return true;
+    }
+
+    private void MovePinnedMruItemUp(object p)
+    {
+        if (p is IMRUEntryViewModel == false)
+            return;
+
+        var param = p as IMRUEntryViewModel;
+
+        MRUFileList.MovePinnedEntry(MoveMRUItem.Up, param);
+    }
+
+    private bool CanMovePinnedMruItemDown(object p)
+    {
+        if (p is IMRUEntryViewModel == false)
+            return false;
+
+        if ((p as IMRUEntryViewModel)?.IsPinned == 0)  //Make sure it is pinned
+            return false;
+
+        return true;
+    }
+
+    private void MovePinnedMruItemDown(object p)
+    {
+        if (p is IMRUEntryViewModel == false)
+            return;
+
+        var param = p as IMRUEntryViewModel;
+
+        MRUFileList.MovePinnedEntry(MoveMRUItem.Down, param);
+    }
+
+    private void CreateNewPBO()
+    {
+        var dlg = new OpenFileDialog
+        {
+            Title = "Load PBO archive",
+            DefaultExt = ".pbo",
+            Filter = "PBO File|*.pbo|Preview BI Files|*.paa;*.rvmat;*.bin;*.pac;*.p3d;*.wrp;*.sqm"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        UpdateMRUItem(dlg.FileName);
+        NavigateToPboExplorerWindow(new PboFile(dlg.FileName, PboFileOption.Create));
+    }
+
+    private void OpenPBOFfile(string path)
+    {
+
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+
+        try
+        {
+            UpdateMRUItem(path);
+            NavigateToPboExplorerWindow(new PboFile(path));
+        }
+        catch (Exception exp)
+        {
+            MessageBox.Show(exp.StackTrace, exp.Message);
+        }
+
+    }
+    
+    private void OpenPBOFileWithDialog()
+    {
+        var dlg = new OpenFileDialog
+        {
+            Title = "Load PBO archive",
+            DefaultExt = ".pbo",
+            Filter = "PBO File|*.pbo|Preview BI Files|*.paa;*.rvmat;*.bin;*.pac;*.p3d;*.wrp;*.sqm"
+        };
+        if (dlg.ShowDialog() != true) return;
+
+        UpdateMRUItem(dlg.FileName);
+        NavigateToPboExplorerWindow(new PboFile(dlg.FileName));
+    }
+
+    // TODO: Abstract dependency on Window  
+    private void NavigateToPboExplorerWindow(PboFile pbo)
+    {
+        new PboExplorerWindow(pbo).Show();
+        CloseRequested?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/PboExplorer/Views/RecentFilesView.xaml
+++ b/PboExplorer/Views/RecentFilesView.xaml
@@ -1,0 +1,142 @@
+﻿<UserControl x:Class="PboExplorer.Views.RecentFilesView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid xmlns:scm="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+          xmlns:dat="clr-namespace:System.Windows.Data;assembly=PresentationFramework"
+          xmlns:ctrl="clr-namespace:MRULib.Controls;assembly=MRULib"
+          xmlns:hyperl="clr-namespace:MRULib.Controls;assembly=MRULib"
+          xmlns:conv="clr-namespace:MRULib.Converters;assembly=MRULib"
+          >
+        <Grid.Resources>
+            <CollectionViewSource Source="{Binding MRUFileList.Entries}" x:Key="collViewEntries"
+                                  IsLiveGroupingRequested="True">
+                <CollectionViewSource.SortDescriptions>
+                    <!--This will sort groups-->
+                    <scm:SortDescription PropertyName="Value.GroupItem.Group" Direction="Ascending" />
+
+                    <!--This will sort items-->
+                    <scm:SortDescription PropertyName="Value.IsPinned" Direction="Ascending"/>
+                    <scm:SortDescription PropertyName="Value.LastUpdate" Direction="Descending"/>
+                </CollectionViewSource.SortDescriptions>
+                <CollectionViewSource.GroupDescriptions>
+                    <dat:PropertyGroupDescription PropertyName="Value.GroupItem.Group" />
+                </CollectionViewSource.GroupDescriptions>
+            </CollectionViewSource>
+            <!-- Use a proxy to bind items to root properties of this collection -->
+            <ctrl:BindingProxy  x:Key="MRUListModelProxy"  Data="{Binding MRUFileList}" />
+
+            <ctrl:BindingProxy  x:Key="WindowContextProxy"  Data="{Binding}" />
+
+            <conv:IntToBoolConverter x:Key="IntToBoolConverter" />
+
+            <!-- Make sure that an entry can either be pinned or unpinned via visibility in contextmenu -->
+            <conv:IntIsPinnedToVisibilityConverter ConvertZeroToVisible="True" x:Key="TrueIntIsPinnedToVisibilityConverter" />
+            <conv:IntIsPinnedToVisibilityConverter ConvertZeroToVisible="False" x:Key="FalseIntIsPinnedToVisibilityConverter" />
+        </Grid.Resources>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        
+        <Button Content="Clear" HorizontalAlignment="Right" Padding="4 2" Margin="2"
+                Command="{Binding Path=Data.ClearAllItemsCommand, Source={StaticResource WindowContextProxy}}"/>
+
+        <ListView Grid.Row="1" ItemsSource="{Binding Source={StaticResource collViewEntries}}"
+                  SelectionMode="Single"
+                  Name="list"
+                  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+            <ListView.ItemContainerStyle>
+                <Style TargetType="{x:Type ListViewItem}">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    <Setter Property="Background" Value="Transparent"/>
+                    <Setter Property="Focusable" Value="False"/>
+                    <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type ListViewItem}">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <Grid Grid.Column="0" Name="TextBlockGridWidth" Margin="3,0">
+                                        <ctrl:PathTrimmingFileHyperlink
+                                            DataContext="{Binding Value}"
+                                            Text ="{Binding PathFileName}"
+                                            NavigateUri="{Binding Path=PathFileName}"
+                                            NavigateUriCommand="{Binding Path=Data.NavigateUriCommand, Source={StaticResource WindowContextProxy}}"
+                                            NavigateUriCommandParameter="{Binding Path=PathFileName}">
+                                            <ctrl:PathTrimmingFileHyperlink.ContextMenu>
+                                                <ContextMenu>
+                                                    <MenuItem Header="Move Up"
+                                                              Command="{Binding Path=Data.MovePinnedMruItemUpCommand, Source={StaticResource WindowContextProxy}}"
+                                                              CommandParameter="{Binding}"/>
+                                                    <MenuItem Header="Move Down"
+                                                              Command="{Binding Path=Data.MovePinnedMruItemDownCommand, Source={StaticResource WindowContextProxy}}"
+                                                              CommandParameter="{Binding}"/>
+                                                    <Separator/>
+                                                    
+                                                    <MenuItem Header="Remove from list"
+                                                              Command="{Binding Path=Data.RemoveItemCommand, Source={StaticResource WindowContextProxy}}"
+                                                              CommandParameter="{Binding}"/>
+                                                    
+                                                    <Separator/>
+                                                    
+                                                    <MenuItem Header="Copy Path to Clipboard"
+                                                              Command="{x:Static hyperl:PathTrimmingFileHyperlink.CopyUri}"
+                                                              CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ContextMenu}}}"/>
+
+                                                    <MenuItem Header="Open containing folder"
+                                                              Command="{x:Static hyperl:PathTrimmingFileHyperlink.OpenContainingFolder}"
+                                                              CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ContextMenu}}}"/>
+                                                </ContextMenu>
+                                            </ctrl:PathTrimmingFileHyperlink.ContextMenu>
+                                            <ctrl:PathTrimmingFileHyperlink.ToolTip>
+                                                <TextBlock>
+                                                    <TextBlock Text="{Binding PathFileName}"/><LineBreak/>
+                                                    <TextBlock Text="{Binding LastUpdate}"/><LineBreak/>
+                                                    <TextBlock Text="{Binding IsPinned}"/>
+                                                </TextBlock>
+                                            </ctrl:PathTrimmingFileHyperlink.ToolTip>
+                                        </ctrl:PathTrimmingFileHyperlink>
+                                    </Grid>
+
+                                    <ctrl:CheckPin Grid.Column="1" Margin="0,0,12,0"
+                                                   HorizontalAlignment="Right" Name="checkPin"
+                                                   IsChecked="{Binding Value.IsPinned, Mode=OneWay,UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IntToBoolConverter}}"
+                                                   Command="{Binding Path=Data.ItemIsPinnedChanged, Source={StaticResource MRUListModelProxy}}"
+                                                   CommandParameter="{Binding Key}"/>
+                                </Grid>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="IsMouseOver" Value="True" >
+                                        <Setter TargetName="checkPin"  Property="IsMouseOverListViewItem" Value="True" />
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </ListView.ItemContainerStyle>
+
+            <ListView.GroupStyle>
+                <GroupStyle>
+                    <GroupStyle.HeaderTemplate>
+                        <DataTemplate>
+                            <!--
+                            https://social.msdn.microsoft.com/Forums/en-US/d2eafb97-a655-4742-a1ab-deeb05fbe6bd/listview-specify-group-name?forum=wpf
+                            https://msdn.microsoft.com/en-us/library/system.windows.data.collectionviewgroup_properties.aspx
+                            -->
+                            <TextBlock Margin="0,6,0,0" FontWeight="Bold" FontSize="14"
+                                       Text="{Binding Items[0].Value.GroupItem.GroupName}"/>
+                        </DataTemplate>
+                    </GroupStyle.HeaderTemplate>
+                </GroupStyle>
+            </ListView.GroupStyle>
+        </ListView>
+    </Grid>
+</UserControl>

--- a/PboExplorer/Views/RecentFilesView.xaml.cs
+++ b/PboExplorer/Views/RecentFilesView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace PboExplorer.Views
+{
+    /// <summary>
+    /// Interaction logic for RecentFilesView.xaml
+    /// </summary>
+    public partial class RecentFilesView : UserControl
+    {
+        public RecentFilesView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/PboExplorer/Windows/SplashWindow.xaml
+++ b/PboExplorer/Windows/SplashWindow.xaml
@@ -3,22 +3,32 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:PboExplorer.Windows"
+        xmlns:conv="clr-namespace:MRULib.Converters;assembly=MRULib"
+        xmlns:ctrl="clr-namespace:MRULib.Controls;assembly=MRULib"
+        xmlns:views="clr-namespace:PboExplorer.Views"
         mc:Ignorable="d"
         Title="PboExplorer 1.0 (BisUtils)" Height="450" Width="800">
 
-    <Window.CommandBindings>
-        <CommandBinding Command="New" Executed="CreateNewPBO" />
-        <CommandBinding Command="Open" Executed="OpenPBOFile" />
-    </Window.CommandBindings>
-    
-    <Grid>
-        <Menu DockPanel.Dock="Top">
-            <MenuItem Header="_File">
-                <MenuItem Header="Open PBO file..." Command="Open" />
-                <MenuItem Header="Create PBO file..." Command="New" />
-            </MenuItem>
-        </Menu>
+    <Window.InputBindings>
+        <KeyBinding Modifiers="Ctrl" Key="N" Command="{Binding CreatePBOCommand}"/>
+        <KeyBinding Modifiers="Ctrl" Key="O" Command="{Binding OpenPBOCommand}"/>
+    </Window.InputBindings>
 
+    <Grid>
+        <!--<Grid.Resources>
+            <conv:ZeroToVisibilityConverter x:Key="zeroToVisibilityConverter" />
+            <ctrl:BindingProxy  x:Key="AppDataContextProxy"  Data="{Binding}" />
+        </Grid.Resources>-->
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+
+        <views:RecentFilesView Grid.Column="0"/>
+
+        <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="10">
+            <Button Content="Open PBO file..."  Command="{Binding OpenPBOCommand}" />
+            <Button Content="Create PBO file..."  Command="{Binding CreatePBOCommand}" Margin="0 10"/>
+        </StackPanel>
     </Grid>
 </Window>

--- a/PboExplorer/Windows/SplashWindow.xaml.cs
+++ b/PboExplorer/Windows/SplashWindow.xaml.cs
@@ -1,20 +1,6 @@
-﻿using Microsoft.Win32;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
-using BisUtils.PBO;
-using Path = System.IO.Path;
+using PboExplorer.ViewModels;
 
 namespace PboExplorer.Windows
 {
@@ -23,35 +9,20 @@ namespace PboExplorer.Windows
     /// </summary>
     public partial class SplashWindow : Window
     {
+        private SplashViewModel _viewModel;
+
         public SplashWindow()
         {
             InitializeComponent();
+            _viewModel = new();
+            _viewModel.CloseRequested += OnCloseRequested;
+            DataContext = _viewModel;
         }
 
-        private void OpenPBOFile(object sender, RoutedEventArgs e)
+        private void OnCloseRequested(object? sender, EventArgs e)
         {
-            var dlg = new OpenFileDialog();
-            dlg.Title = "Load PBO archive";
-            dlg.DefaultExt = ".pbo";
-            dlg.Filter = "PBO File|*.pbo|Preview BI Files|*.paa;*.rvmat;*.bin;*.pac;*.p3d;*.wrp;*.sqm";
-            if (dlg.ShowDialog() != true) return;
-            
-            new PboExplorerWindow(new PboFile(dlg.FileName)).Show();
-            Close();
-
-        }
-
-        private void CreateNewPBO(object sender, RoutedEventArgs e)
-        {
-            var dlg = new OpenFileDialog();
-            dlg.Title = "Load PBO archive";
-            dlg.DefaultExt = ".pbo";
-            dlg.Filter = "PBO File|*.pbo|Preview BI Files|*.paa;*.rvmat;*.bin;*.pac;*.p3d;*.wrp;*.sqm";
-            if (dlg.ShowDialog() != true) return;
-            new PboExplorerWindow(new PboFile(dlg.FileName, PboFileOption.Create)).Show();
+            _viewModel.CloseRequested -= OnCloseRequested;
             Close();
         }
-
-       
     }
 }


### PR DESCRIPTION
Currently `SplashWindow` has little to no utility, so I decided to add feature to it.

![image](https://user-images.githubusercontent.com/48875452/207960523-ca27a43e-5618-424d-939c-869bf835c95d.png)

Again like #4 , idk where to put `RecentFilesView` so I put it into `Views` although it's "control" (which probably should be placed in `Utils/Elements`) and not complete "veiw".

`MRULib` follows MVVM pattern so I added (messy) view model which shared between `SplashWindow` and `RecentFilesView`. Normally it should be split into separate VMs and some MRU service which handles persistence. But currently it's more "PoC code" and I don't want to push MVVM if you're not familiar with it.

### Changes

- Add persisted list of MRU files to `SplashWindow` via [MRULib package](https://www.nuget.org/packages/Dirkster.MRULib);
- Refactor `SplashWindow` code-behind;
- Introduce view model for `SplashWindow`.