### PR TITLE
Start migration to MVVM

### DIFF
--- a/PboExplorer/App.xaml
+++ b/PboExplorer/App.xaml
@@ -9,9 +9,13 @@
             DataType="{x:Type interfaces:ITreeEnumerableItem}"
             ItemsSource="{Binding TreeChildren}">
             <StackPanel Orientation="Horizontal">
-                <TextBlock 
-                        Text="{Binding Title}" 
-                        DockPanel.Dock="Right"/>
+                <TextBlock Text="{Binding Title}" 
+                        DockPanel.Dock="Right">
+                    <TextBlock.InputBindings>
+                        <MouseBinding Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type TreeView}}, Path=DataContext.OpenPreviewCommand}"
+                                              CommandParameter="{Binding .}" MouseAction="LeftDoubleClick"/>
+                    </TextBlock.InputBindings>
+                </TextBlock>
                 <TextBlock
                         Name="EditedText"
                         Visibility="Hidden"

--- a/PboExplorer/App.xaml
+++ b/PboExplorer/App.xaml
@@ -2,8 +2,23 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:PboExplorer"
+             xmlns:interfaces="clr-namespace:PboExplorer.Utils.Interfaces"
              StartupUri="/Windows/Splash/SplashWindow.xaml">
     <Application.Resources>
-         
+        <HierarchicalDataTemplate x:Key="EntryTreeTemplate"
+            DataType="{x:Type interfaces:ITreeEnumerableItem}"
+            ItemsSource="{Binding TreeChildren}">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock 
+                        Text="{Binding Title}" 
+                        DockPanel.Dock="Right"/>
+                <TextBlock
+                        Name="EditedText"
+                        Visibility="Hidden"
+                        Margin="5 0 0 0"
+                        Text="(edited)"
+                        DockPanel.Dock="Left"/>
+            </StackPanel>
+        </HierarchicalDataTemplate>
     </Application.Resources>
 </Application>

--- a/PboExplorer/Messages/ActivateDocumentMessage.cs
+++ b/PboExplorer/Messages/ActivateDocumentMessage.cs
@@ -1,0 +1,13 @@
+﻿using PboExplorer.Models;
+
+namespace PboExplorer.Messages;
+
+public class ActivateDocumentMessage
+{
+    public TreeDataEntry Data { get; }
+
+	public ActivateDocumentMessage(TreeDataEntry data)
+	{
+		Data= data;
+	}
+}

--- a/PboExplorer/PboExplorer.csproj
+++ b/PboExplorer/PboExplorer.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="BisUtils.Core" Version="1.0.34" />
     <PackageReference Include="BisUtils.PBO" Version="1.0.23" />
     <PackageReference Include="Clowd.Squirrel" Version="2.9.42" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
     <PackageReference Include="Dirkster.AvalonDock" Version="4.70.3" />
     <PackageReference Include="Dirkster.MRULib" Version="1.3.0" />
     <PackageReference Include="System.Runtime.Caching" Version="7.0.0" />

--- a/PboExplorer/Utils/Interfaces/IPane.cs
+++ b/PboExplorer/Utils/Interfaces/IPane.cs
@@ -1,0 +1,10 @@
+﻿namespace PboExplorer.Utils.Interfaces;
+
+public interface IPane
+{
+    string Title { get; }
+
+    bool IsVisible { get; set; }
+    
+    // TODO: Add other members as needed
+}

--- a/PboExplorer/ViewModels/EntryViewModel.cs
+++ b/PboExplorer/ViewModels/EntryViewModel.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Input;
 
-using MRULib.MRU.ViewModels.Base;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
 using PboExplorer.Models;
 using PboExplorer.Utils.Interfaces;
 
@@ -13,29 +13,15 @@ namespace PboExplorer.ViewModels;
 
 /// <summary>
 /// Base class for PBO entires view models
-/// TODO: use MVVM framework implementation for INotifyPropertyChanged
 /// </summary>
-public abstract class EntryViewModel : IDocument, INotifyPropertyChanged
+public abstract partial class EntryViewModel : ObservableObject, IDocument
 {
     protected readonly TreeDataEntry _model;
-    private string _title;
-    private bool _isDirty;
-
-    public string Title {
-        get => _title;
-        set {
-            _title = value;
-            OnPropertyChanged();
-        }
-    }
     
-    protected bool IsDirty {
-        get => _isDirty;
-        set {
-            _isDirty = value;
-            OnPropertyChanged();
-        }
-    }
+    [ObservableProperty]
+    private string _title;
+    [ObservableProperty]
+    private bool _isDirty;
     
     public ICommand CloseCommand { get; }
     public ICommand SaveCommand { get; }
@@ -47,10 +33,10 @@ public abstract class EntryViewModel : IDocument, INotifyPropertyChanged
     {
         _model = model;
         _title = title;
+        _isDirty= false;
 
-        // TODO: In case of adoption MVVM framework replace MRULib's RelayCommand
-        CloseCommand = new RelayCommand<object>(_ => Close());
-        SaveCommand = new RelayCommand<object>(_ => SaveToPbo());
+        CloseCommand = new RelayCommand(Close);
+        SaveCommand = new RelayCommand(SaveToPbo);
     }
 
     public bool IsDocumentFor(TreeDataEntry entry)
@@ -94,12 +80,4 @@ public abstract class EntryViewModel : IDocument, INotifyPropertyChanged
         CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 
-    #region INotifyPropertyChanged boilerplate
-    public event PropertyChangedEventHandler? PropertyChanged;
-
-    protected void OnPropertyChanged([CallerMemberName] string name = null!)
-    {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-    }
-    #endregion
 }

--- a/PboExplorer/ViewModels/Panes/ConfigTreePaneViewModel.cs
+++ b/PboExplorer/ViewModels/Panes/ConfigTreePaneViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace PboExplorer.ViewModels.Panes;
+
+public partial class ConfigTreePaneViewModel : PaneViewModel
+{
+    public override string Title => "Config Files";
+
+}

--- a/PboExplorer/ViewModels/Panes/EntryInformationPaneViewModel.cs
+++ b/PboExplorer/ViewModels/Panes/EntryInformationPaneViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace PboExplorer.ViewModels.Panes;
+
+public partial class EntryInformationPaneViewModel : PaneViewModel
+{
+    public override string Title => "Entry Information";
+
+}

--- a/PboExplorer/ViewModels/Panes/FileTreePaneViewModel.cs
+++ b/PboExplorer/ViewModels/Panes/FileTreePaneViewModel.cs
@@ -1,4 +1,8 @@
-﻿using PboExplorer.Utils.Interfaces;
+﻿using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using PboExplorer.Messages;
+using PboExplorer.Models;
+using PboExplorer.Utils.Interfaces;
 using PboExplorer.Utils.Managers;
 using System.Collections.ObjectModel;
 
@@ -17,4 +21,12 @@ public partial class FileTreePaneViewModel : PaneViewModel
         _treeManager = treeManager;
     }
 
+    [RelayCommand]
+    public void OpenPreview(ITreeItem item)
+    {
+        if (item is TreeDataEntry entry)
+        {
+            WeakReferenceMessenger.Default.Send(new ActivateDocumentMessage(entry));
+        }
+    }
 }

--- a/PboExplorer/ViewModels/Panes/FileTreePaneViewModel.cs
+++ b/PboExplorer/ViewModels/Panes/FileTreePaneViewModel.cs
@@ -1,0 +1,20 @@
+﻿using PboExplorer.Utils.Interfaces;
+using PboExplorer.Utils.Managers;
+using System.Collections.ObjectModel;
+
+namespace PboExplorer.ViewModels.Panes;
+
+public partial class FileTreePaneViewModel : PaneViewModel
+{
+    private readonly EntryTreeManager _treeManager;
+
+    public override string Title => "Pbo Explorer";
+
+    public ObservableCollection<ITreeItem> Entries => _treeManager.EntryRoot.TreeChildren;
+
+    public FileTreePaneViewModel(EntryTreeManager treeManager)
+    {
+        _treeManager = treeManager;
+    }
+
+}

--- a/PboExplorer/ViewModels/Panes/PaneViewModel.cs
+++ b/PboExplorer/ViewModels/Panes/PaneViewModel.cs
@@ -1,0 +1,12 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PboExplorer.Utils.Interfaces;
+
+namespace PboExplorer.ViewModels;
+
+public abstract partial class PaneViewModel : ObservableObject, IPane
+{
+    [ObservableProperty]
+    protected bool _isVisible = true;
+
+    public abstract string Title { get; }
+}

--- a/PboExplorer/ViewModels/Panes/PboMetadataPaneViewModel.cs
+++ b/PboExplorer/ViewModels/Panes/PboMetadataPaneViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace PboExplorer.ViewModels.Panes;
+
+public partial class PboMetadataPaneViewModel : PaneViewModel
+{
+    public override string Title => "PBO Metadata";
+
+}

--- a/PboExplorer/ViewModels/Panes/SearchResultsPaneViewModel.cs
+++ b/PboExplorer/ViewModels/Panes/SearchResultsPaneViewModel.cs
@@ -1,7 +1,30 @@
-﻿namespace PboExplorer.ViewModels.Panes;
+﻿using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using PboExplorer.Messages;
+using PboExplorer.Models;
+using PboExplorer.Utils.Managers;
+using System.Collections.ObjectModel;
+
+namespace PboExplorer.ViewModels.Panes;
 
 public partial class SearchResultsPaneViewModel : PaneViewModel
 {
-    public override string Title => "Search Results";
+    private readonly EntryTreeManager _treeManager;
 
+    public override string Title => "Search Results";
+    public ObservableCollection<FileSearchResult> Results => _treeManager.SearchResults;
+
+    public SearchResultsPaneViewModel(EntryTreeManager treeManager)
+    {
+        _treeManager = treeManager;
+    }
+
+    [RelayCommand]
+    public void OpenPreview(object item)
+    {
+        if (item is SearchResult result)
+        {
+            WeakReferenceMessenger.Default.Send(new ActivateDocumentMessage(result.File));
+        }
+    }
 }

--- a/PboExplorer/ViewModels/Panes/SearchResultsPaneViewModel.cs
+++ b/PboExplorer/ViewModels/Panes/SearchResultsPaneViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace PboExplorer.ViewModels.Panes;
+
+public partial class SearchResultsPaneViewModel : PaneViewModel
+{
+    public override string Title => "Search Results";
+
+}

--- a/PboExplorer/ViewModels/PboExplorerViewModel.cs
+++ b/PboExplorer/ViewModels/PboExplorerViewModel.cs
@@ -2,6 +2,8 @@
 using CommunityToolkit.Mvvm.Messaging;
 using PboExplorer.Messages;
 using PboExplorer.Utils.Interfaces;
+using PboExplorer.Utils.Managers;
+using PboExplorer.ViewModels.Panes;
 using System;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -17,11 +19,18 @@ public partial class PboExplorerViewModel : ObservableObject, IDisposable, IReci
     private IDocument? _activeDocument;
 
     public ObservableCollection<IDocument> Documents { get; } = new();
+    public ObservableCollection<IPane> Panes { get; } = new();
 
-    public PboExplorerViewModel()
+    public PboExplorerViewModel(EntryTreeManager treeManager) // CONSIDER: inject pane vms directly
     {
         Documents.CollectionChanged += OnDocumentsCollectionChanged;
         Documents.Add(new AboutEntryViewModel());
+
+        Panes.Add(new FileTreePaneViewModel(treeManager));
+        Panes.Add(new ConfigTreePaneViewModel());
+        Panes.Add(new PboMetadataPaneViewModel());
+        Panes.Add(new SearchResultsPaneViewModel());
+        Panes.Add(new EntryInformationPaneViewModel());
 
         WeakReferenceMessenger.Default.Register(this);
     }

--- a/PboExplorer/ViewModels/PboExplorerViewModel.cs
+++ b/PboExplorer/ViewModels/PboExplorerViewModel.cs
@@ -1,0 +1,98 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
+using PboExplorer.Messages;
+using PboExplorer.Utils.Interfaces;
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+
+namespace PboExplorer.ViewModels;
+
+public partial class PboExplorerViewModel : ObservableObject, IDisposable, IRecipient<ActivateDocumentMessage>
+{
+    private bool _disposed;
+    [ObservableProperty]
+    private IDocument? _activeDocument;
+
+    public ObservableCollection<IDocument> Documents { get; } = new();
+
+    public PboExplorerViewModel()
+    {
+        Documents.CollectionChanged += OnDocumentsCollectionChanged;
+        Documents.Add(new AboutEntryViewModel());
+
+        WeakReferenceMessenger.Default.Register(this);
+    }
+
+    public async void Receive(ActivateDocumentMessage message)
+    {
+        var treeManager = message.Data.TreeManager; // TODO: Consider refactoring 
+
+        treeManager.SelectedEntry = message.Data;
+        var opened = Documents.Where(doc => doc.IsDocumentFor(message.Data));
+
+        if (!opened.Any())
+        {
+            var text = Encoding.UTF8.GetString((await treeManager.DataRepository.GetOrCreateEntryDataStream(message.Data)).ToArray());  // TODO: Consider refactoring 
+            var doc = new TextEntryViewModel(message.Data, text);
+            Documents.Add(doc);
+            ActiveDocument = doc;
+        }
+        else
+        {
+            ActiveDocument = opened.FirstOrDefault();
+        }
+    }
+
+    private void OnDocumentsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        switch (e.Action)
+        {
+            case NotifyCollectionChangedAction.Add:
+                foreach (var doc in e.NewItems?.Cast<IDocument>())
+                {
+                    doc.CloseRequested += OnDocumentCloseRequested;
+                }
+                break;
+            case NotifyCollectionChangedAction.Remove:
+                foreach (var doc in e.OldItems?.Cast<IDocument>())
+                {
+                    doc.CloseRequested -= OnDocumentCloseRequested;
+                }
+                break;
+        }
+    }
+
+    private void OnDocumentCloseRequested(object? sender, EventArgs e)
+    {
+        if (sender is IDocument doc)
+        {
+            Documents.Remove(doc);
+        }
+    }
+
+    #region IDisposable
+    ~PboExplorerViewModel() => Dispose(false);
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        Documents.CollectionChanged -= OnDocumentsCollectionChanged;
+
+        _disposed = true;
+    }
+
+    #endregion
+}

--- a/PboExplorer/Windows/PboExplorer/LayoutInitializer.cs
+++ b/PboExplorer/Windows/PboExplorer/LayoutInitializer.cs
@@ -1,0 +1,62 @@
+﻿using AvalonDock.Layout;
+using PboExplorer.Utils.Interfaces;
+using PboExplorer.ViewModels.Panes;
+using System.Linq;
+
+namespace PboExplorer.Windows.PboExplorer;
+
+class LayoutInitializer : ILayoutUpdateStrategy
+{
+    public bool BeforeInsertAnchorable(LayoutRoot layout, LayoutAnchorable anchorableToShow, ILayoutContainer destinationContainer)
+    {
+        //AD wants to add the anchorable into destinationContainer
+        //just for test provide a new anchorablepane 
+        //if the pane is floating let the manager go ahead
+        LayoutAnchorablePane? destPane = destinationContainer as LayoutAnchorablePane;
+        if (destinationContainer?.FindParent<LayoutFloatingWindow>() != null)
+            return false;
+
+        if (anchorableToShow.Content is IPane)
+        {
+            var leftPane = layout.Descendents()
+                .OfType<LayoutAnchorablePane>()
+                .FirstOrDefault(d => d.Name == "LeftPane");
+
+            var bottomPane = layout.Descendents()
+                .OfType<LayoutAnchorablePane>()
+                .FirstOrDefault(d => d.Name == "BottomPane");
+
+            var dest = anchorableToShow.Content switch
+            {
+                FileTreePaneViewModel or ConfigTreePaneViewModel => leftPane,
+                SearchResultsPaneViewModel or EntryInformationPaneViewModel or PboMetadataPaneViewModel => bottomPane,
+                _ => bottomPane ?? leftPane
+            };
+
+            if (dest != null)
+            {
+                anchorableToShow.CanClose = false;
+                dest.Children.Add(anchorableToShow);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    public void AfterInsertAnchorable(LayoutRoot layout, LayoutAnchorable anchorableShown)
+    {
+    }
+
+
+    public bool BeforeInsertDocument(LayoutRoot layout, LayoutDocument anchorableToShow, ILayoutContainer destinationContainer)
+    {
+        return false;
+    }
+
+    public void AfterInsertDocument(LayoutRoot layout, LayoutDocument anchorableShown)
+    {
+
+    }
+}

--- a/PboExplorer/Windows/PboExplorer/PaneStyleSelector.cs
+++ b/PboExplorer/Windows/PboExplorer/PaneStyleSelector.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 using System.Windows;
 using PboExplorer.Utils.Interfaces;
 
@@ -11,13 +6,16 @@ namespace PboExplorer.Windows.PboExplorer;
 
 class PanesStyleSelector : StyleSelector
 {
+    public Style PaneStyle { get; set; }
     public Style DocumentStyle { get; set; }
 
-    public override System.Windows.Style SelectStyle(object item, System.Windows.DependencyObject container)
+    public override Style SelectStyle(object item, DependencyObject container)
     {
-        if (item is IDocument)
-            return DocumentStyle;
-
-        return base.SelectStyle(item, container);
+        return item switch
+        {
+            IPane => PaneStyle,
+            IDocument => DocumentStyle,
+            _ => base.SelectStyle(item, container)
+        };
     }
 }

--- a/PboExplorer/Windows/PboExplorer/PaneTemplateSelector.cs
+++ b/PboExplorer/Windows/PboExplorer/PaneTemplateSelector.cs
@@ -1,23 +1,35 @@
 ﻿using System.Windows.Controls;
 using System.Windows;
 using PboExplorer.ViewModels;
+using PboExplorer.ViewModels.Panes;
 
 namespace PboExplorer.Windows.PboExplorer;
 
+// TODO: Refactor
 class PanesTemplateSelector : DataTemplateSelector
 {
-    public DataTemplate AboutViewTemplate {get;set;}
+    public DataTemplate AboutViewTemplate { get; set; }
 
-    public DataTemplate TextViewTemplate {get;set;}
+    public DataTemplate TextViewTemplate { get; set; }
+
+    public DataTemplate FileTreePaneTemplate { get; set; }
+    public DataTemplate ConfigTreePaneTemplate { get; set; }
+    public DataTemplate SearchResultsPaneTemplate { get; set; }
+    public DataTemplate PboMetaDataPaneTemplate { get; set; }
+    public DataTemplate EntryInformationPaneTemplate { get; set; }
 
     public override DataTemplate SelectTemplate(object item, DependencyObject container)
     {
-        if (item is AboutEntryViewModel)
-            return AboutViewTemplate;
-
-        if (item is TextEntryViewModel)
-            return TextViewTemplate;
-
-        return base.SelectTemplate(item, container);
+        return item switch
+        {
+            AboutEntryViewModel => AboutViewTemplate,
+            TextEntryViewModel => TextViewTemplate,
+            FileTreePaneViewModel => FileTreePaneTemplate,
+            ConfigTreePaneViewModel => ConfigTreePaneTemplate,
+            SearchResultsPaneViewModel => SearchResultsPaneTemplate,
+            PboMetadataPaneViewModel => PboMetaDataPaneTemplate,
+            EntryInformationPaneViewModel => EntryInformationPaneTemplate,
+            _ => base.SelectTemplate(item, container)
+        };
     }
 }

--- a/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml
+++ b/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml
@@ -92,9 +92,8 @@
                 />
         </Menu>
 
-        <dock:DockingManager x:Name="DockManager"
-            ActiveContent="{Binding Path=ActiveDocument, RelativeSource={RelativeSource Mode=FindAncestor,
-                                    AncestorType=Window}, Mode=TwoWay, Converter={converters:ActiveDocumentConverter}}"
+        <dock:DockingManager x:Name="DockManager" DocumentsSource="{Binding Documents}"
+            ActiveContent="{Binding Path=ActiveDocument, Mode=TwoWay, Converter={converters:ActiveDocumentConverter}}"
             AllowMixedOrientation="True"
             AutoWindowSizeWhenOpened="True"
             IsVirtualizingAnchorable="True"
@@ -139,9 +138,7 @@
                             </TreeView>
                         </LayoutAnchorable>
                         <LayoutAnchorable Title="Config Files" CanClose="False" CanHide="False">
-                            <TreeView Name="ConfigView" 
-                                      SelectedItemChanged="ConfigView_SelectedItemChanged" 
-                                      VirtualizingStackPanel.IsVirtualizing="True"/>
+                            <TreeView Name="ConfigView" VirtualizingStackPanel.IsVirtualizing="True"/>
                         </LayoutAnchorable>
                     </dock:LayoutAnchorablePane>
 

--- a/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml
+++ b/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml
@@ -11,12 +11,11 @@
         mc:Ignorable="d"
         Title="PboExplorerWindow" Height="450" Width="800">
 
-    <Window.CommandBindings>
-        <CommandBinding Command="Save" CanExecute="CanSave" Executed="Save"/>
-    </Window.CommandBindings>
-
+    <!--TODO: Fix applticatin commands-->
     <Window.InputBindings>
-        <KeyBinding Command="Save" Modifiers="Control" Key="S"/>
+        <KeyBinding Command="{Binding ExitCommand}" Modifiers="Ctrl" Key="E"/>
+        <KeyBinding Command="{Binding SaveCommand}" Modifiers="Ctrl" Key="S"/>
+        <KeyBinding Command="{Binding SaveAsCommand}" Modifiers="Ctrl+Shift" Key="S"/>
     </Window.InputBindings>
 
     <Window.Resources>
@@ -25,16 +24,12 @@
     <DockPanel>
         <Menu DockPanel.Dock="Top">
             <MenuItem Header="_File">
-                <MenuItem 
-                    Header="_Save..."
-                    Click="Save"
-                />
-                <MenuItem 
-                    Header="_Save _as..."
-                    Click="SaveAs"/>
-                <MenuItem
-                    Header="Close"
-                    Click="Close"/>
+                <MenuItem Header="_Save..." Command="{Binding SaveCommand}"
+                          InputGestureText="Ctrl+S"/>
+                <MenuItem Header="_Save _as..." Command="{Binding SaveAsCommand}"
+                          InputGestureText="Ctrl+Shift+S"/>
+                <MenuItem Header="Close" Command="{Binding ExitCommand}"
+                          InputGestureText="Ctrl+E"/>
             </MenuItem>
             <MenuItem Header="_Edit">
                 <MenuItem 
@@ -55,25 +50,20 @@
 
             </MenuItem>
 
-            <Separator></Separator>
+            <Separator/>
 
-            <TextBox
-                Name="SearchBox"
-                Tag="Search"
+            <TextBox Text="{Binding SearchTerm, UpdateSourceTrigger=PropertyChanged}"
                 VerticalAlignment="Center"
                 MinWidth="115"
-                Width="150"
-                />
-            <Button
-                VerticalAlignment="Stretch"
-                Margin="3"
-                MaxHeight="25"
-                MinWidth="50"
-                Name="SearchButton"
-                Content="Search"
-                VerticalContentAlignment="Center"
-                Click="SearchButton_Click"
-                />
+                Width="150"/>
+            <Button Command="{Binding SearchCommand}"
+                    CommandParameter="{Binding SearchTerm}"
+                    VerticalAlignment="Stretch"
+                    Margin="3"
+                    MaxHeight="25"
+                    MinWidth="50"
+                    Content="Search"
+                    VerticalContentAlignment="Center"/>
         </Menu>
 
         <dock:DockingManager x:Name="DockManager"

--- a/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml
+++ b/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml
@@ -5,11 +5,9 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:dock="https://github.com/Dirkster99/AvalonDock"
         xmlns:local="clr-namespace:PboExplorer.Windows.PboExplorer"
-        xmlns:models="clr-namespace:PboExplorer.Models"
         xmlns:converters="clr-namespace:PboExplorer.Utils.Converters"
         xmlns:views="clr-namespace:PboExplorer.Windows.PboExplorer.Views"
         xmlns:aboutViews="clr-namespace:PboExplorer.Windows.PboExplorer.Views.About"
-        xmlns:interfaces="clr-namespace:PboExplorer.Utils.Interfaces"
         mc:Ignorable="d"
         Title="PboExplorerWindow" Height="450" Width="800">
 
@@ -22,21 +20,7 @@
     </Window.InputBindings>
 
     <Window.Resources>
-        <HierarchicalDataTemplate x:Key="EntryTreeTemplate"
-            DataType="{x:Type interfaces:ITreeEnumerableItem}"
-            ItemsSource="{Binding TreeChildren}">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock 
-                        Text="{Binding Title}" 
-                        DockPanel.Dock="Right"/>
-                <TextBlock
-                        Name="EditedText"
-                        Visibility="Hidden"
-                        Margin="5 0 0 0"
-                        Text="(edited)"
-                        DockPanel.Dock="Left"/>
-            </StackPanel>
-        </HierarchicalDataTemplate>
+        <dock:BoolToVisibilityConverter x:Key="AvalonBoolToVisibilityConverter" />
     </Window.Resources>
     <DockPanel>
         <Menu DockPanel.Dock="Top">
@@ -92,12 +76,19 @@
                 />
         </Menu>
 
-        <dock:DockingManager x:Name="DockManager" DocumentsSource="{Binding Documents}"
-            ActiveContent="{Binding Path=ActiveDocument, Mode=TwoWay, Converter={converters:ActiveDocumentConverter}}"
-            AllowMixedOrientation="True"
-            AutoWindowSizeWhenOpened="True"
-            IsVirtualizingAnchorable="True"
-            IsVirtualizingDocument="True">
+        <dock:DockingManager x:Name="DockManager"
+                             ActiveContent="{Binding Path=ActiveDocument, Mode=TwoWay, Converter={converters:ActiveDocumentConverter}}"
+                             DocumentsSource="{Binding Documents}"
+                             AnchorablesSource="{Binding Panes}" 
+                             AllowMixedOrientation="True" 
+                             AutoWindowSizeWhenOpened="True" 
+                             IsVirtualizingAnchorable="True" 
+                             IsVirtualizingDocument="True">
+            <dock:DockingManager.LayoutUpdateStrategy>
+                <local:LayoutInitializer />
+            </dock:DockingManager.LayoutUpdateStrategy>
+            
+            <!--TODO: Refactor-->
             <dock:DockingManager.LayoutItemTemplateSelector>
                 <local:PanesTemplateSelector>
                     <local:PanesTemplateSelector.AboutViewTemplate>
@@ -110,10 +101,42 @@
                             <views:TextEntryView/>
                         </DataTemplate>
                     </local:PanesTemplateSelector.TextViewTemplate>
+                    <local:PanesTemplateSelector.FileTreePaneTemplate>
+                        <DataTemplate>
+                            <views:FileTreePaneView/>
+                        </DataTemplate>
+                    </local:PanesTemplateSelector.FileTreePaneTemplate>
+                    <local:PanesTemplateSelector.ConfigTreePaneTemplate>
+                        <DataTemplate>
+                            <views:ConfigTreePaneView/>
+                        </DataTemplate>
+                    </local:PanesTemplateSelector.ConfigTreePaneTemplate>
+                    <local:PanesTemplateSelector.SearchResultsPaneTemplate>
+                        <DataTemplate>
+                            <views:SearchResultsPaneView/>
+                        </DataTemplate>
+                    </local:PanesTemplateSelector.SearchResultsPaneTemplate>
+                    <local:PanesTemplateSelector.PboMetaDataPaneTemplate>
+                        <DataTemplate>
+                            <views:PboMetadataPaneView/>
+                        </DataTemplate>
+                    </local:PanesTemplateSelector.PboMetaDataPaneTemplate>
+                    <local:PanesTemplateSelector.EntryInformationPaneTemplate>
+                        <DataTemplate>
+                            <views:EntryInformationPaneView/>
+                        </DataTemplate>
+                    </local:PanesTemplateSelector.EntryInformationPaneTemplate>
                 </local:PanesTemplateSelector>
             </dock:DockingManager.LayoutItemTemplateSelector>
+            
             <dock:DockingManager.LayoutItemContainerStyleSelector>
                 <local:PanesStyleSelector>
+                    <local:PanesStyleSelector.PaneStyle>
+                        <Style TargetType="{x:Type dock:LayoutAnchorableItem}">
+                            <Setter Property="Title" Value="{Binding Model.Title}"/>
+                            <Setter Property="Visibility" Value="{Binding Model.IsVisible, Mode=TwoWay, Converter={StaticResource AvalonBoolToVisibilityConverter}, ConverterParameter={x:Static Visibility.Hidden}}"/>
+                        </Style>
+                    </local:PanesStyleSelector.PaneStyle>
                     <local:PanesStyleSelector.DocumentStyle>
                         <Style TargetType="{x:Type LayoutItem}">
                             <Setter Property="Title" Value="{Binding Model.Title}" />
@@ -122,105 +145,18 @@
                     </local:PanesStyleSelector.DocumentStyle>
                 </local:PanesStyleSelector>
             </dock:DockingManager.LayoutItemContainerStyleSelector>
+            
             <dock:LayoutRoot>
                 <dock:LayoutPanel Orientation="Horizontal">
 
-                    <dock:LayoutAnchorablePane DockMinWidth="200">
-                        <LayoutAnchorable Title="PBO Entries" CanClose="False" CanHide="False">
-                            <TreeView Name="PboView" 
-                                      ItemTemplate="{StaticResource EntryTreeTemplate}"
-                                      VirtualizingStackPanel.IsVirtualizing="True">
-                                <TreeView.ItemContainerStyle>
-                                    <Style TargetType="TreeViewItem">
-                                        <EventSetter Event="MouseDoubleClick" Handler="OnViewPboEntry"/>
-                                    </Style>
-                                </TreeView.ItemContainerStyle>
-                            </TreeView>
-                        </LayoutAnchorable>
-                        <LayoutAnchorable Title="Config Files" CanClose="False" CanHide="False">
-                            <TreeView Name="ConfigView" VirtualizingStackPanel.IsVirtualizing="True"/>
-                        </LayoutAnchorable>
-                    </dock:LayoutAnchorablePane>
+                    <dock:LayoutAnchorablePane Name="LeftPane" DockMinWidth="200"/>
 
                     <dock:LayoutPanel Orientation="Vertical">
                         <dock:LayoutDocumentPaneGroup>
                             <dock:LayoutDocumentPane x:Name="LayoutDocumentPane" />
                         </dock:LayoutDocumentPaneGroup>
 
-                        <dock:LayoutAnchorablePane DockHeight="100">
-                            <dock:LayoutAnchorable Title="Search Results" CanClose="False" CanHide="False">
-                                <TreeView Name="SearchResultsView" 
-                                          VirtualizingStackPanel.IsVirtualizing="True">
-                                    <TreeView.ItemContainerStyle>
-                                        <Style TargetType="TreeViewItem">
-                                            <EventSetter Event="MouseDoubleClick" Handler="OnViewSearchResult"/>
-                                        </Style>
-                                    </TreeView.ItemContainerStyle>
-                                    <TreeView.Resources>
-                                        <HierarchicalDataTemplate DataType="{x:Type models:FileSearchResult}"
-                                                          ItemsSource="{Binding SearchResults}">
-                                            <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="{Binding File.FullPath}"/>
-                                            </StackPanel>
-                                        </HierarchicalDataTemplate>
-                                        <DataTemplate  DataType="{x:Type models:SearchResult}">
-                                            <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="{Binding AsString}" />
-                                                <TextBlock Text=":  " />
-                                                <TextBlock Text="{Binding LineText}" />
-                                            </StackPanel>
-                                        </DataTemplate>
-                                    </TreeView.Resources>
-                                </TreeView>
-                            </dock:LayoutAnchorable>
-                            <dock:LayoutAnchorable Title="PBO Metadata" CanClose="False" CanHide="False">
-                                <Grid>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="200" />
-                                        <RowDefinition />
-                                    </Grid.RowDefinitions>
-                                    <DataGrid Name="EntryInfoGrid" IsReadOnly="True" AutoGenerateColumns="False" Grid.Row="0">
-                                        <DataGrid.Columns>
-                                            <DataGridTextColumn 
-                                        Header="Property" 
-                                        Binding="{Binding Name}" 
-                                        Width="1*">
-
-                                            </DataGridTextColumn>
-                                            <DataGridTextColumn 
-                                        Header="Value" 
-                                        Binding="{Binding Value}" 
-                                        Width="3*">
-
-                                            </DataGridTextColumn>
-                                        </DataGrid.Columns>
-                                    </DataGrid>
-                                </Grid>
-                            </dock:LayoutAnchorable>
-                            <dock:LayoutAnchorable Title="Entry Information" CanClose="False" CanHide="False">
-                                <Grid>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="200" />
-                                        <RowDefinition />
-                                    </Grid.RowDefinitions>
-                                    <DataGrid Name="EntryInformationGrid" IsReadOnly="True" AutoGenerateColumns="False" Grid.Row="0">
-                                        <DataGrid.Columns>
-                                            <DataGridTextColumn 
-                                        Header="Key" 
-                                        Binding="{Binding Key}" 
-                                        Width="1*">
-                                            </DataGridTextColumn>
-                                            <DataGridTextColumn 
-                                        Header="Value" 
-                                        Binding="{Binding Value}" 
-                                        Width="3*">
-
-                                            </DataGridTextColumn>
-                                        </DataGrid.Columns>
-                                    </DataGrid>
-                                </Grid>
-                            </dock:LayoutAnchorable>
-                        </dock:LayoutAnchorablePane>
+                        <dock:LayoutAnchorablePane Name="BottomPane" DockHeight="100"/>
                     </dock:LayoutPanel>
                 </dock:LayoutPanel>
             </dock:LayoutRoot>

--- a/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml.cs
+++ b/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml.cs
@@ -3,9 +3,6 @@ using System.Text;
 using System.Windows;
 using System.Windows.Input;
 using BisUtils.PBO;
-using CommunityToolkit.Mvvm.Messaging;
-using PboExplorer.Messages;
-using PboExplorer.Models;
 using PboExplorer.Utils.Managers;
 using PboExplorer.ViewModels;
 
@@ -16,25 +13,20 @@ namespace PboExplorer.Windows.PboExplorer
     /// </summary>
     public partial class PboExplorerWindow {
         private readonly EntryTreeManager TreeManager; // TODO: Move to singleton service
-
+        private readonly PboExplorerViewModel _viewModel;
+        
         public PboExplorerWindow(PboFile pboFile) {
             InitializeComponent();
             TreeManager = new EntryTreeManager(pboFile);
 
-            DataContext = new PboExplorerViewModel(TreeManager);
+            _viewModel= new PboExplorerViewModel(TreeManager);
+            _viewModel.ExitRequested += OnExitRequested;
+            DataContext = _viewModel;
         }
 
-        private void SaveAs(object sender, RoutedEventArgs e) {
-            throw new NotImplementedException();
-            //TODO: This will be hard since we have a cache implemented 
-        }
-
-        // TODO: Move to appropriate VM
-        private async void Save(object sender, RoutedEventArgs e) => 
-            await TreeManager.DataRepository.SaveAllEditedEntries();
-
-        // TODO: Move to appropriate VM
-        private void Close(object sender, RoutedEventArgs e) {
+        private void OnExitRequested(object? sender, EventArgs e)
+        {
+            _viewModel.ExitRequested -= OnExitRequested;
             TreeManager.Dispose();
             Close();
         }
@@ -45,7 +37,7 @@ namespace PboExplorer.Windows.PboExplorer
             Clipboard.SetText(TreeManager.SelectedEntry.FullPath);
         }
 
-        // TODO: Move to FileTreePane VM
+        // TODO: Move to FileTreePane Or Entry VM
         private async void CopySelectedEntryData(object sender, RoutedEventArgs e) {
             if(TreeManager.SelectedEntry is null) return;
             Clipboard.SetText(Encoding.UTF8.GetString((await TreeManager.GetCurrentEntryData()).ToArray()));
@@ -59,43 +51,6 @@ namespace PboExplorer.Windows.PboExplorer
         // TODO: Move to appropriate VM
         private void AddEntryWizard(object sender, RoutedEventArgs e) {
             throw new NotImplementedException();
-        }
-        
-        // TODO: Move to appropriate VM
-        private void CanSave(object sender, CanExecuteRoutedEventArgs e) =>
-            e.CanExecute = TreeManager.DataRepository.AreFilesEdited();
-        
-        // TODO: Move to appropriate VM (possibly PboExplorerViewModel)
-        private async void SearchButton_Click(object sender, RoutedEventArgs e) {
-            var search = SearchBox.Text;
-            if(string.IsNullOrWhiteSpace(search)) return;
-            TreeManager.ClearSearchResults();
-            //SearchResultsView.ItemsSource = TreeManager.SearchResults;
-            SearchButton.IsEnabled = false;
-            TreeManager.SearchResults.Clear();
-            foreach (var fileSearchResult in await TreeManager.SearchForString(search, false)) TreeManager.SearchResults.Add(fileSearchResult);
-            SearchButton.IsEnabled = true;
-        }
-        
-        // TODO: Move to FileTreePane VM
-        private void OnViewPboEntry(object sender, MouseButtonEventArgs e) {
-            var fe = sender as FrameworkElement;
-            switch (fe?.DataContext) {
-                case TreeDataEntry treeDataEntry:
-                    WeakReferenceMessenger.Default.Send(new ActivateDocumentMessage(treeDataEntry));
-                    break;
-                default: return;
-            }
-        }
-
-        // TODO: Move to SearchResultsPane VM
-        private void OnViewSearchResult(object sender, MouseButtonEventArgs e) {
-            var fe = sender as FrameworkElement;
-            switch (fe?.DataContext){
-                case SearchResult searchResult:
-                    WeakReferenceMessenger.Default.Send(new ActivateDocumentMessage(searchResult.File));
-                    break;
-            }
         }
     }
 }

--- a/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml.cs
+++ b/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml.cs
@@ -1,16 +1,11 @@
 ﻿using System;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Input;
 using BisUtils.PBO;
+using CommunityToolkit.Mvvm.Messaging;
+using PboExplorer.Messages;
 using PboExplorer.Models;
-using PboExplorer.Utils.Interfaces;
 using PboExplorer.Utils.Managers;
 using PboExplorer.ViewModels;
 
@@ -19,82 +14,59 @@ namespace PboExplorer.Windows.PboExplorer
     /// <summary>
     /// Interaction logic for PboExplorerWindow.xaml
     /// </summary>
-    //TODO: Remove INotifyPropertyChanged, for demonstration purposes only
-    public partial class PboExplorerWindow: INotifyPropertyChanged {
-        private readonly EntryTreeManager TreeManager;
-        private readonly ObservableCollection<IDocument> _documents = new();
-        private IDocument? _activeDocument;
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-
-        public IDocument? ActiveDocument { 
-            get => _activeDocument;
-            set {
-                _activeDocument= value;
-                PropertyChanged?.Invoke(this, new(nameof(ActiveDocument)));
-            }
-        }
+    public partial class PboExplorerWindow {
+        private readonly EntryTreeManager TreeManager; // TODO: Move to appropriate VM
 
         public PboExplorerWindow(PboFile pboFile) {
             InitializeComponent();
             TreeManager = new EntryTreeManager(pboFile);
             PboView.ItemsSource = TreeManager.EntryRoot.TreeChildren;
 
-            _documents.CollectionChanged += OnDocumentsCollectionChanged;
-            _documents.Add(new AboutEntryViewModel());
-            DockManager.DocumentsSource =_documents;
+            DataContext = new PboExplorerViewModel();
         }
 
         private void SaveAs(object sender, RoutedEventArgs e) {
             throw new NotImplementedException();
             //TODO: This will be hard since we have a cache implemented 
         }
-        
+
+        // TODO: Move to appropriate VM
         private async void Save(object sender, RoutedEventArgs e) => 
             await TreeManager.DataRepository.SaveAllEditedEntries();
 
+        // TODO: Move to appropriate VM
         private void Close(object sender, RoutedEventArgs e) {
             TreeManager.Dispose();
             Close();
         }
-
+        
+        // TODO: Move to appropriate VM
         private void CopySelectedEntryName(object sender, RoutedEventArgs e) {
             if(TreeManager.SelectedEntry is null) return;
             Clipboard.SetText(TreeManager.SelectedEntry.FullPath);
         }
-        
 
+        // TODO: Move to appropriate VM
         private async void CopySelectedEntryData(object sender, RoutedEventArgs e) {
             if(TreeManager.SelectedEntry is null) return;
             Clipboard.SetText(Encoding.UTF8.GetString((await TreeManager.GetCurrentEntryData()).ToArray()));
         }
-
+        
+        // TODO: Move to appropriate VM
         private void DeleteSelectedEntry(object sender, RoutedEventArgs e) {
             throw new NotImplementedException();
         }
 
+        // TODO: Move to appropriate VM
         private void AddEntryWizard(object sender, RoutedEventArgs e) {
             throw new NotImplementedException();
         }
         
-        private async Task ShowPboEntry(TreeDataEntry treeDataEntry) {
-            TreeManager.SelectedEntry = treeDataEntry;
-            var opened = _documents.Where(doc => doc.IsDocumentFor(treeDataEntry));
-
-            if (!opened.Any()) {
-                var text = Encoding.UTF8.GetString((await TreeManager.DataRepository.GetOrCreateEntryDataStream(treeDataEntry)).ToArray());
-                var doc = new TextEntryViewModel(treeDataEntry, text);
-                _documents.Add(doc);
-                ActiveDocument = doc;
-            }
-            else {
-                ActiveDocument = opened.FirstOrDefault();
-            }
-        }
-
+        // TODO: Move to appropriate VM
         private void CanSave(object sender, CanExecuteRoutedEventArgs e) =>
             e.CanExecute = TreeManager.DataRepository.AreFilesEdited();
-
+        
+        // TODO: Move to appropriate VM
         private async void SearchButton_Click(object sender, RoutedEventArgs e) {
             var search = SearchBox.Text;
             if(string.IsNullOrWhiteSpace(search)) return;
@@ -105,55 +77,25 @@ namespace PboExplorer.Windows.PboExplorer
             foreach (var fileSearchResult in await TreeManager.SearchForString(search, false)) TreeManager.SearchResults.Add(fileSearchResult);
             SearchButton.IsEnabled = true;
         }
-
-        private async void OnViewPboEntry(object sender, MouseButtonEventArgs e) {
+        
+        // TODO: Move to appropriate VM
+        private void OnViewPboEntry(object sender, MouseButtonEventArgs e) {
             var fe = sender as FrameworkElement;
             switch (fe?.DataContext) {
                 case TreeDataEntry treeDataEntry:
-                    await ShowPboEntry(treeDataEntry);
+                    WeakReferenceMessenger.Default.Send(new ActivateDocumentMessage(treeDataEntry));
                     break;
                 default: return;
             }
         }
 
-        //TODO: Consider handling the double click event
-        private void ConfigView_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e) {
-            throw new NotImplementedException();
-        }
-
-        private async void OnViewSearchResult(object sender, MouseButtonEventArgs e) {
+        // TODO: Move to appropriate VM
+        private void OnViewSearchResult(object sender, MouseButtonEventArgs e) {
             var fe = sender as FrameworkElement;
             switch (fe?.DataContext){
                 case SearchResult searchResult:
-                    await ShowPboEntry(searchResult.File);
+                    WeakReferenceMessenger.Default.Send(new ActivateDocumentMessage(searchResult.File));
                     break;
-            }
-        }
-
-        private void OnDocumentsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-        {
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                    foreach (var doc in e.NewItems?.Cast<IDocument>())
-                    {
-                        doc.CloseRequested += OnDocumentCloseRequested;
-                    }
-                    break;
-                case NotifyCollectionChangedAction.Remove:
-                    foreach (var doc in e.OldItems?.Cast<IDocument>())
-                    {
-                        doc.CloseRequested -= OnDocumentCloseRequested;
-                    }
-                    break;
-            }
-        }
-
-        private void OnDocumentCloseRequested(object? sender, EventArgs e)
-        {
-            if (sender is IDocument doc)
-            {
-                _documents.Remove(doc);
             }
         }
     }

--- a/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml.cs
+++ b/PboExplorer/Windows/PboExplorer/PboExplorerWindow.xaml.cs
@@ -15,14 +15,13 @@ namespace PboExplorer.Windows.PboExplorer
     /// Interaction logic for PboExplorerWindow.xaml
     /// </summary>
     public partial class PboExplorerWindow {
-        private readonly EntryTreeManager TreeManager; // TODO: Move to appropriate VM
+        private readonly EntryTreeManager TreeManager; // TODO: Move to singleton service
 
         public PboExplorerWindow(PboFile pboFile) {
             InitializeComponent();
             TreeManager = new EntryTreeManager(pboFile);
-            PboView.ItemsSource = TreeManager.EntryRoot.TreeChildren;
 
-            DataContext = new PboExplorerViewModel();
+            DataContext = new PboExplorerViewModel(TreeManager);
         }
 
         private void SaveAs(object sender, RoutedEventArgs e) {
@@ -39,20 +38,20 @@ namespace PboExplorer.Windows.PboExplorer
             TreeManager.Dispose();
             Close();
         }
-        
-        // TODO: Move to appropriate VM
+
+        // TODO: Move to FileTreePane VM
         private void CopySelectedEntryName(object sender, RoutedEventArgs e) {
             if(TreeManager.SelectedEntry is null) return;
             Clipboard.SetText(TreeManager.SelectedEntry.FullPath);
         }
 
-        // TODO: Move to appropriate VM
+        // TODO: Move to FileTreePane VM
         private async void CopySelectedEntryData(object sender, RoutedEventArgs e) {
             if(TreeManager.SelectedEntry is null) return;
             Clipboard.SetText(Encoding.UTF8.GetString((await TreeManager.GetCurrentEntryData()).ToArray()));
         }
-        
-        // TODO: Move to appropriate VM
+
+        // TODO: Move to FileTreePane VM
         private void DeleteSelectedEntry(object sender, RoutedEventArgs e) {
             throw new NotImplementedException();
         }
@@ -66,19 +65,19 @@ namespace PboExplorer.Windows.PboExplorer
         private void CanSave(object sender, CanExecuteRoutedEventArgs e) =>
             e.CanExecute = TreeManager.DataRepository.AreFilesEdited();
         
-        // TODO: Move to appropriate VM
+        // TODO: Move to appropriate VM (possibly PboExplorerViewModel)
         private async void SearchButton_Click(object sender, RoutedEventArgs e) {
             var search = SearchBox.Text;
             if(string.IsNullOrWhiteSpace(search)) return;
             TreeManager.ClearSearchResults();
-            SearchResultsView.ItemsSource = TreeManager.SearchResults;
+            //SearchResultsView.ItemsSource = TreeManager.SearchResults;
             SearchButton.IsEnabled = false;
             TreeManager.SearchResults.Clear();
             foreach (var fileSearchResult in await TreeManager.SearchForString(search, false)) TreeManager.SearchResults.Add(fileSearchResult);
             SearchButton.IsEnabled = true;
         }
         
-        // TODO: Move to appropriate VM
+        // TODO: Move to FileTreePane VM
         private void OnViewPboEntry(object sender, MouseButtonEventArgs e) {
             var fe = sender as FrameworkElement;
             switch (fe?.DataContext) {
@@ -89,7 +88,7 @@ namespace PboExplorer.Windows.PboExplorer
             }
         }
 
-        // TODO: Move to appropriate VM
+        // TODO: Move to SearchResultsPane VM
         private void OnViewSearchResult(object sender, MouseButtonEventArgs e) {
             var fe = sender as FrameworkElement;
             switch (fe?.DataContext){

--- a/PboExplorer/Windows/PboExplorer/Views/ConfigTreePaneView.xaml
+++ b/PboExplorer/Windows/PboExplorer/Views/ConfigTreePaneView.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl x:Class="PboExplorer.Windows.PboExplorer.Views.ConfigTreePaneView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:PboExplorer.Windows.PboExplorer.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <TreeView Name="ConfigView" VirtualizingStackPanel.IsVirtualizing="True"/>
+    </Grid>
+</UserControl>

--- a/PboExplorer/Windows/PboExplorer/Views/ConfigTreePaneView.xaml.cs
+++ b/PboExplorer/Windows/PboExplorer/Views/ConfigTreePaneView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace PboExplorer.Windows.PboExplorer.Views
+{
+    /// <summary>
+    /// Interaction logic for ConfigTreePaneView.xaml
+    /// </summary>
+    public partial class ConfigTreePaneView : UserControl
+    {
+        public ConfigTreePaneView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/PboExplorer/Windows/PboExplorer/Views/EntryInformationPaneView.xaml
+++ b/PboExplorer/Windows/PboExplorer/Views/EntryInformationPaneView.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="PboExplorer.Windows.PboExplorer.Views.EntryInformationPaneView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:PboExplorer.Windows.PboExplorer.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <DataGrid Name="EntryInformationGrid" IsReadOnly="True" AutoGenerateColumns="False" Grid.Row="0">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Key" Binding="{Binding Key}" Width="1*"/>
+                <DataGridTextColumn Header="Value" Binding="{Binding Value}" Width="3*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</UserControl>

--- a/PboExplorer/Windows/PboExplorer/Views/EntryInformationPaneView.xaml.cs
+++ b/PboExplorer/Windows/PboExplorer/Views/EntryInformationPaneView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace PboExplorer.Windows.PboExplorer.Views
+{
+    /// <summary>
+    /// Interaction logic for EntryInformationPaneView.xaml
+    /// </summary>
+    public partial class EntryInformationPaneView : UserControl
+    {
+        public EntryInformationPaneView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/PboExplorer/Windows/PboExplorer/Views/FileTreePaneView.xaml
+++ b/PboExplorer/Windows/PboExplorer/Views/FileTreePaneView.xaml
@@ -8,14 +8,8 @@
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
         <TreeView ItemsSource="{Binding Entries}" 
-                  ItemTemplate="{StaticResource EntryTreeTemplate}" 
+                  ItemTemplate="{StaticResource EntryTreeTemplate}"
                   VirtualizingStackPanel.IsVirtualizing="True">
-            <!--TODO: Implement-->
-            <!--<TreeView.ItemContainerStyle>
-                <Style TargetType="TreeViewItem">
-                    <EventSetter Event="MouseDoubleClick" Handler="OnViewPboEntry"/>
-                </Style>
-            </TreeView.ItemContainerStyle>-->
         </TreeView>
     </Grid>
 </UserControl>

--- a/PboExplorer/Windows/PboExplorer/Views/FileTreePaneView.xaml
+++ b/PboExplorer/Windows/PboExplorer/Views/FileTreePaneView.xaml
@@ -1,0 +1,21 @@
+﻿<UserControl x:Class="PboExplorer.Windows.PboExplorer.Views.FileTreePaneView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:PboExplorer.Windows.PboExplorer.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <TreeView ItemsSource="{Binding Entries}" 
+                  ItemTemplate="{StaticResource EntryTreeTemplate}" 
+                  VirtualizingStackPanel.IsVirtualizing="True">
+            <!--TODO: Implement-->
+            <!--<TreeView.ItemContainerStyle>
+                <Style TargetType="TreeViewItem">
+                    <EventSetter Event="MouseDoubleClick" Handler="OnViewPboEntry"/>
+                </Style>
+            </TreeView.ItemContainerStyle>-->
+        </TreeView>
+    </Grid>
+</UserControl>

--- a/PboExplorer/Windows/PboExplorer/Views/FileTreePaneView.xaml.cs
+++ b/PboExplorer/Windows/PboExplorer/Views/FileTreePaneView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace PboExplorer.Windows.PboExplorer.Views
+{
+    /// <summary>
+    /// Interaction logic for FileTreePaneViewModel.xaml
+    /// </summary>
+    public partial class FileTreePaneView : UserControl
+    {
+        public FileTreePaneView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/PboExplorer/Windows/PboExplorer/Views/PboMetadataPaneView.xaml
+++ b/PboExplorer/Windows/PboExplorer/Views/PboMetadataPaneView.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="PboExplorer.Windows.PboExplorer.Views.PboMetadataPaneView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:PboExplorer.Windows.PboExplorer.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <DataGrid Name="EntryInfoGrid" IsReadOnly="True" AutoGenerateColumns="False" Grid.Row="0">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Property" Binding="{Binding Name}" Width="1*"/>
+                <DataGridTextColumn Header="Value" Binding="{Binding Value}" Width="3*" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</UserControl>

--- a/PboExplorer/Windows/PboExplorer/Views/PboMetadataPaneView.xaml.cs
+++ b/PboExplorer/Windows/PboExplorer/Views/PboMetadataPaneView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace PboExplorer.Windows.PboExplorer.Views
+{
+    /// <summary>
+    /// Interaction logic for PboMetadataPaneView.xaml
+    /// </summary>
+    public partial class PboMetadataPaneView : UserControl
+    {
+        public PboMetadataPaneView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/PboExplorer/Windows/PboExplorer/Views/SearchResultsPaneView.xaml
+++ b/PboExplorer/Windows/PboExplorer/Views/SearchResultsPaneView.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl x:Class="PboExplorer.Windows.PboExplorer.Views.SearchResultsPaneView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:PboExplorer.Windows.PboExplorer.Views"
+             xmlns:models="clr-namespace:PboExplorer.Models"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <TreeView Name="SearchResultsView" VirtualizingStackPanel.IsVirtualizing="True">
+            <!--TODO: Implement-->
+            <!--<TreeView.ItemContainerStyle>
+                <Style TargetType="TreeViewItem">
+                    <EventSetter Event="MouseDoubleClick" Handler="OnViewSearchResult"/>
+                </Style>
+            </TreeView.ItemContainerStyle>-->
+            <TreeView.Resources>
+                <HierarchicalDataTemplate DataType="{x:Type models:FileSearchResult}" 
+                                          ItemsSource="{Binding SearchResults}">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding File.FullPath}"/>
+                    </StackPanel>
+                </HierarchicalDataTemplate>
+                <DataTemplate  DataType="{x:Type models:SearchResult}">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding AsString}" />
+                        <TextBlock Text=":  " />
+                        <TextBlock Text="{Binding LineText}" />
+                    </StackPanel>
+                </DataTemplate>
+            </TreeView.Resources>
+        </TreeView>
+    </Grid>
+</UserControl>

--- a/PboExplorer/Windows/PboExplorer/Views/SearchResultsPaneView.xaml
+++ b/PboExplorer/Windows/PboExplorer/Views/SearchResultsPaneView.xaml
@@ -8,13 +8,7 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
-        <TreeView Name="SearchResultsView" VirtualizingStackPanel.IsVirtualizing="True">
-            <!--TODO: Implement-->
-            <!--<TreeView.ItemContainerStyle>
-                <Style TargetType="TreeViewItem">
-                    <EventSetter Event="MouseDoubleClick" Handler="OnViewSearchResult"/>
-                </Style>
-            </TreeView.ItemContainerStyle>-->
+        <TreeView ItemsSource="{Binding Results}" VirtualizingStackPanel.IsVirtualizing="True">
             <TreeView.Resources>
                 <HierarchicalDataTemplate DataType="{x:Type models:FileSearchResult}" 
                                           ItemsSource="{Binding SearchResults}">
@@ -22,8 +16,13 @@
                         <TextBlock Text="{Binding File.FullPath}"/>
                     </StackPanel>
                 </HierarchicalDataTemplate>
+                
                 <DataTemplate  DataType="{x:Type models:SearchResult}">
                     <StackPanel Orientation="Horizontal">
+                        <StackPanel.InputBindings>
+                            <MouseBinding Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type TreeView}}, Path=DataContext.OpenPreviewCommand}"
+                                          CommandParameter="{Binding .}" MouseAction="LeftDoubleClick"/>
+                        </StackPanel.InputBindings>
                         <TextBlock Text="{Binding AsString}" />
                         <TextBlock Text=":  " />
                         <TextBlock Text="{Binding LineText}" />

--- a/PboExplorer/Windows/PboExplorer/Views/SearchResultsPaneView.xaml.cs
+++ b/PboExplorer/Windows/PboExplorer/Views/SearchResultsPaneView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace PboExplorer.Windows.PboExplorer.Views
+{
+    /// <summary>
+    /// Interaction logic for SearchResultsPaneView.xaml
+    /// </summary>
+    public partial class SearchResultsPaneView : UserControl
+    {
+        public SearchResultsPaneView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Glad to hear your response in #6 ! Today I started refactoring according to plan outlined in #7. 

Initially, I planned to wire some libraries (for mvvm and probably for [interactivity](https://www.nuget.org/packages/Microsoft.Xaml.Behaviors.Wpf)), add infrastructure boilerplate (DI, `appsettings` etc) and clean some TODOs. But I realized that it won't be beneficial before splitting `PboExplorerWindow`'s code-behind. So I started breaking it into view models and it took longer than I expected.

I opened this PR to let you know, and I'll keep it as a draft until I've scaffolded VMs for `PboExplorerWindow`.